### PR TITLE
feat(data): Implement scaled scraper and refined multi-setting preprocessor

### DIFF
--- a/data_pipeline/preprocess_data.py
+++ b/data_pipeline/preprocess_data.py
@@ -1,168 +1,109 @@
 import json
-import random # For potential random splitting
-import traceback # For more detailed error logging
+import re # For splitting by X:
+import traceback
 
 print("preprocess_data.py: Loaded.")
 
-def split_abc_tune(full_abc_text, split_point_bars=4, min_completion_bars=2):
+def split_abc_tune(single_setting_abc, split_point_bars=4, min_completion_bars=4):
     """
-    Splits a full ABC tune into a prompt (start) and completion (rest).
-    Assumes bars are separated by '|'.
+    Takes a SINGLE ABC tune/setting and splits it into a prompt/completion pair.
+    This version has stricter checks.
     """
-    # CORRECTED NEWLINE SPLITTING HERE:
-    lines = full_abc_text.strip().split('\n') # Use actual newline '\n'
+    lines = single_setting_abc.strip().split('\n')
     header_lines = []
-    music_lines_text = []
+    music_lines = []
+    
+    # Separate header (lines before K:) and music (lines from K: onwards)
+    try:
+        k_index = -1
+        for i, line in enumerate(lines):
+            if line.strip().startswith("K:"):
+                k_index = i
+                break
+        if k_index == -1: return None, None # No key signature, invalid ABC for our purpose
 
-    # Heuristic to separate header from music lines
-    # This can be improved, e.g. by looking for the K: field as the end of typical headers
-    key_field_found = False
-    for line in lines:
-        line_stripped = line.strip()
-        if not line_stripped: # skip empty lines
-            continue
-        
-        # A common pattern: headers end when K: is found or music notation starts
-        if not key_field_found:
-            if line_stripped.startswith("K:"):
-                header_lines.append(line_stripped)
-                key_field_found = True # From here on, assume music lines
-            elif line_stripped.startswith(('X:', 'T:', 'M:', 'L:', 'R:', 'C:', 'S:', 'Z:', 'N:', 'O:', 'A:', 'B:', 'Q:', 'P:')):
-                header_lines.append(line_stripped)
-            elif key_field_found: # If K: was already found, subsequent lines are music
-                music_lines_text.append(line_stripped)
-            else: # Before K: if it's not a recognized header, might be music or other info
-                  # For now, let's assume lines not matching typical headers before K: are part of the music section
-                  # or an unhandled header type. A more robust parser would handle this better.
-                  # A simple check: if it contains '|' or notes (a-g, A-G) it's likely music.
-                if '|' in line_stripped or any(c in "abcdefgABCDEFG" for c in line_stripped):
-                    music_lines_text.append(line_stripped)
-                else: # Otherwise, assume it's part of the header block
-                    header_lines.append(line_stripped)
-        else: # After K: field, all non-empty lines are music
-            music_lines_text.append(line_stripped)
-
-    if not header_lines or not music_lines_text:
-        print(f"Debug: Could not separate header/music for tune. Header: {len(header_lines)}, Music: {len(music_lines_text)}. Tune: {full_abc_text[:100]}...")
+        header_lines = lines[:k_index+1]
+        music_lines = lines[k_index+1:]
+    except Exception:
         return None, None
-    if not key_field_found and "K:" not in "\n".join(header_lines): # Double check K: presence
-        print(f"Warning: No K: field clearly identified in header for tune starting with {header_lines[0] if header_lines else 'N/A'}")
-        # Depending on strictness, you might return None, None here
+    
+    if not music_lines: return None, None
 
-    # Process music lines
-    full_music_notation = " ".join(music_lines_text)
-    # Normalize multiple spaces that might result from joining lines, then split by bar
+    full_music_notation = " ".join(music_lines)
     bars = [b.strip() for b in ' '.join(full_music_notation.split()).split('|')]
-    bars = [b for b in bars if b] # Remove empty strings
+    bars = [b for b in bars if b and not b.isspace()] # Filter out empty/whitespace bars
 
     if len(bars) < split_point_bars + min_completion_bars:
-        print(f"Debug: Tune too short. Total bars: {len(bars)}, Required: {split_point_bars + min_completion_bars}. Tune: {header_lines[0] if header_lines else 'N/A'}")
-        return None, None
+        return None, None # Tune is too short
 
-    prompt_bars_list = bars[:split_point_bars]
-    completion_bars_list = bars[split_point_bars:]
+    prompt_bars = bars[:split_point_bars]
+    completion_bars = bars[split_point_bars:]
+    
+    if not prompt_bars or not completion_bars: return None, None
+    
+    prompt_abc_full = "\n".join(header_lines) + "\n" + " | ".join(prompt_bars) + " |"
+    completion_text = " | ".join(completion_bars).strip()
+    
+    # Final check: if completion is just an end marker, discard it
+    if completion_text in (':|', '||', '|]'): return None, None
 
-    if not prompt_bars_list or not completion_bars_list:
-        print(f"Debug: Prompt or completion bars list is empty after split. Tune: {header_lines[0] if header_lines else 'N/A'}")
-        return None, None
+    return prompt_abc_full, completion_text
 
-    prompt_abc_music = " | ".join(prompt_bars_list) + " |"
-    prompt_abc_full = "\n".join(header_lines) + "\n" + prompt_abc_music
-
-    completion_abc_music = " | ".join(completion_bars_list)
-    # Basic check to ensure completion isn't just an end bar like '||' or ':|'
-    if completion_abc_music.strip() in ('||', ':|', '|]', '|'):
-        print(f"Debug: Completion part is only an end bar symbol. Tune: {header_lines[0] if header_lines else 'N/A'}")
-        return None, None # Completion is too short or just an end marker
-
-    # Ensure completion ends correctly if it's the end of a piece (already in your code, good)
-    # This might need adjustment based on how the source ABC terminates tunes.
-    # For now, if it's not a double bar or repeat, we add a single bar.
-    # It's better if the source data has proper termination.
-    cleaned_completion = completion_abc_music.strip()
-    if not cleaned_completion.endswith(('||', ':|', '|]')):
-         if cleaned_completion and not cleaned_completion.endswith('|'):
-             cleaned_completion += " |"
-         elif not cleaned_completion: # if completion is empty after stripping, it's problematic
-            print(f"Debug: Completion part is empty after stripping. Tune: {header_lines[0] if header_lines else 'N/A'}")
-            return None, None
-
-
-    # Final basic validation placeholder
-    # Could add: check for balanced repeats, valid characters, etc.
-    # For now, a simple check that K: is in the prompt part.
-    if "K:" not in prompt_abc_full:
-        print(f"Warning: No K: field in prompt part. Prompt: {prompt_abc_full[:100]}...")
-        # return None, None # Decide if this is a fatal error for V1
-
-    return prompt_abc_full.strip(), cleaned_completion.strip()
-
-
-# --- Keep create_finetuning_record and process_scraped_data as they were in the previous correct version ---
-# --- (or as they are in your Cell 10 if they were already good) ---
 def create_finetuning_record(prompt_abc, completion_abc, instruction="Please continue this musical piece in a similar style:"):
-    if not prompt_abc or not completion_abc:
-        return None
+    if not prompt_abc or not completion_abc: return None
     prompt_text = f"Human: {instruction}\n{prompt_abc}</s> Assistant: "
-    record = {
-        "prompt": prompt_text,
-        "completion": completion_abc
-    }
-    return record
+    return {"prompt": prompt_text, "completion": completion_abc}
 
-def process_scraped_data(input_filename="initial_scraped_tunes_v1.txt",
-                         output_jsonl_filename="finetuning_dataset_v1.jsonl", # Changed default
-                         max_examples=50):
-    tune_separator = "%-------------------- TUNE SEPARATOR --------------------%"
+def process_scraped_data(input_filename, output_jsonl_filename, max_examples=10000):
+    """Reads scraped ABC data, splits multi-setting blocks, and creates a JSONL dataset."""
+    fetched_block_separator = "%-------------------- TUNE SEPARATOR --------------------%"
     records_created = 0
-    number_of_tunes_found = 0
 
     try:
         with open(input_filename, 'r', encoding='utf-8') as infile:
             full_content = infile.read()
         
-        individual_tunes_raw = full_content.split(tune_separator)
-        individual_tunes = [tune.strip() for tune in individual_tunes_raw if tune.strip()]
-        number_of_tunes_found = len(individual_tunes)
-        
-        print(f"Found {number_of_tunes_found} actual tunes in {input_filename} after splitting by separator and stripping.")
+        # Split into blocks from different URLs
+        fetched_blocks = full_content.split(fetched_block_separator)
+        print(f"Found {len(fetched_blocks)} fetched blocks in {input_filename}.")
 
+        all_individual_settings = []
+        for tune_block_raw in fetched_blocks:
+            if not tune_block_raw.strip(): continue
+            # Split each block by the X: header to get individual settings/versions
+            # The regex splits on a newline that is FOLLOWED BY "X:", keeping the "X:"
+            settings_in_block = re.split(r'\n(?=X:)', tune_block_raw.strip())
+            all_individual_settings.extend(settings_in_block)
+
+        print(f"Total individual tune settings found: {len(all_individual_settings)}")
+        
         with open(output_jsonl_filename, 'w', encoding='utf-8') as outfile:
-            for full_abc_tune in individual_tunes:
+            for setting_abc in all_individual_settings:
                 if records_created >= max_examples:
                     print(f"Reached max_examples limit of {max_examples}.")
                     break
                 
-                print(f"\nProcessing tune: {full_abc_tune[: min(100, len(full_abc_tune))]}...")
-                prompt_part, completion_part = split_abc_tune(full_abc_tune)
+                prompt_part, completion_part = split_abc_tune(setting_abc)
 
                 if prompt_part and completion_part:
                     record = create_finetuning_record(prompt_part, completion_part)
                     if record:
-                        # Corrected way to write JSONL with a proper newline
-                        outfile.write(json.dumps(record) + '\n') 
-                        # OR, preferred:
-                        # print(json.dumps(record), file=outfile) 
-                        
+                        outfile.write(json.dumps(record) + '\n')
                         records_created += 1
-                        print(f"SUCCESS: Created record {records_created}/{max_examples}")
-                        if records_created < 5: 
-                            print(json.dumps(record, indent=2)) # For pretty printing to console
-                else:
-                    print(f"SKIPPED tune due to splitting issue or insufficient length. Tune preview: {full_abc_tune.strip()[:100]}...")
-    
+                        if records_created % 100 == 0:
+                            print(f"Progress: {records_created} records created...")
+            
     except FileNotFoundError:
-        print(f"Error: Input file {input_filename} not found. Scraper might not have run successfully.")
+        print(f"Error: Input file {input_filename} not found.")
     except Exception as e:
         print(f"An error occurred during preprocessing: {e}")
         traceback.print_exc()
 
     print(f"\nFinished preprocessing. Created {records_created} records in {output_jsonl_filename}.")
-    # ... (rest of the warnings) ...
 
 if __name__ == "__main__":
-    print("Running preprocess_data.py as main script for testing...")
-    # Ensure the output filename matches what fine_tune.py expects
-    process_scraped_data(input_filename="initial_scraped_tunes_v1.txt",
-                         output_jsonl_filename="finetuning_dataset_v1_sample.jsonl", 
-                         max_examples=50)
+    print("Running preprocess_data.py for scaled data acquisition...")
+    process_scraped_data(
+        input_filename="initial_scraped_tunes_large_v1.txt",
+        output_jsonl_filename="finetuning_dataset_large_v1.jsonl"
+    )

--- a/scraper.py
+++ b/scraper.py
@@ -1,66 +1,24 @@
 import requests
 from bs4 import BeautifulSoup
 import time
+import traceback
 
 print("scraper.py: Loaded.")
 
 def get_abc_from_url(url):
-    """Fetches a page. If it's a known direct /abc endpoint, returns the text. Otherwise, tries basic HTML parsing."""
-    print(f"Attempting to fetch ABC from: {url}")
+    """Fetches a page. If it's a known direct /abc endpoint, returns the text."""
+    # This function is already quite robust from our previous work.
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
-
-        # Check if the URL itself indicates it's a raw ABC endpoint (more reliable for thesession.org)
-        if url.endswith("/abc"): # Specific check for thesession.org /abc pattern
-            print(f"URL ends with /abc, assuming direct ABC content for {url}.")
+        if url.endswith("/abc"):
             abc_text = response.text.strip()
-            if abc_text:
-                # Sometimes these /abc endpoints might still have a bit of HTML or other text if an error occurs on their side
-                # A simple check: ABC usually starts with X:
-                if abc_text.lstrip().startswith("X:"):
-                    print(f"Content from {url} starts with 'X:', confirmed as ABC.")
-                    return [abc_text]
-                else:
-                    print(f"Content from {url} does not start with 'X:'. It might not be raw ABC. Content preview: {abc_text[:200]}")
-                    # Try basic HTML parsing as a fallback if it wasn't plain text but was an /abc URL
-                    # This part is less likely to be hit for valid /abc URLs from thesession
-                    soup = BeautifulSoup(response.content, 'html.parser')
-                    pre_tags = soup.find_all('pre')
-                    if pre_tags:
-                        abc_texts = [pre.get_text(separator='\n', strip=True) for pre in pre_tags if pre.get_text(strip=True).lstrip().startswith("X:")]
-                        if abc_texts:
-                            print(f"Found {len(abc_texts)} ABC string(s) via fallback HTML 'pre' tag parsing on {url}")
-                            return abc_texts
-                    print(f"No valid ABC found even with fallback parsing for /abc URL: {url}")
-                    return []
-            else:
-                print(f"Empty content from direct /abc pattern URL: {url}")
-                return []
-        else:
-            # Fallback to BeautifulSoup for pages that might embed ABC in HTML (for other, non-/abc URL sites)
-            print(f"URL does not end with /abc. Attempting general HTML parsing for {url}.")
-            soup = BeautifulSoup(response.content, 'html.parser')
-            # This is a generic placeholder - WILL LIKELY NEED ADJUSTMENT FOR OTHER SITES
-            abc_elements = soup.find_all('pre', class_='abc-notation')
-            if not abc_elements:
-                abc_elements = soup.find_all('div', id='abc-content')
-            if not abc_elements: # Broader search if specific classes fail
-                 abc_elements = soup.find_all('pre')
-
-
-            abc_texts = [element.get_text(separator='\n', strip=True) for element in abc_elements if element.get_text(strip=True).lstrip().startswith("X:")]
-
-            if abc_texts:
-                print(f"Found {len(abc_texts)} ABC string(s) via HTML parsing on {url}")
-                return abc_texts
-            else:
-                print(f"No ABC notation found via HTML parsing on {url} with current selectors.")
-                return []
-
+            if abc_text and abc_text.lstrip().startswith("X:"):
+                return [abc_text]
+        return []
     except requests.exceptions.HTTPError as http_err:
-        if response.status_code == 404: # Check if response object exists
-            print(f"Error 404: Tune not found at {url}")
+        if hasattr(http_err.response, 'status_code') and http_err.response.status_code == 404:
+            pass # Suppress 404 errors for mass scraping, it's expected some tunes don't exist.
         else:
             print(f"HTTP error fetching {url}: {http_err}")
         return []
@@ -69,35 +27,53 @@ def get_abc_from_url(url):
         return []
     except Exception as e:
         print(f"An unexpected error occurred while processing {url}: {e}")
-        import traceback
-        traceback.print_exc()
         return []
 
-def save_abc_data(abc_strings_list, filename="scraped_abc_data.txt"):
+def save_abc_data(abc_strings_list, filename="scraped_abc_data_large.txt"):
+    """Saves a list of ABC strings to a file, each on a new block separated by a standard marker."""
     tune_separator = "\n\n%-------------------- TUNE SEPARATOR --------------------%\n\n"
-    with open(filename, 'w', encoding='utf-8') as f:
+    with open(filename, 'w', encoding='utf-8') as f: # Use 'w' to overwrite the file each time this script runs
         for i, abc_string in enumerate(abc_strings_list):
             f.write(abc_string.strip())
-            if i < len(abc_strings_list) - 1:
+            if i < len(abc_strings_list) - 1: # Don't add separator after the last item
                 f.write(tune_separator)
-    print(f"Saved {len(abc_strings_list)} ABC string(s) to {filename}")
+    print(f"Saved {len(abc_strings_list)} ABC string blocks to {filename}")
 
 
 if __name__ == "__main__":
-    print("Running scraper.py as main script for testing...")
-    target_urls = [
-        "https://thesession.org/tunes/1/abc",
-        "https://thesession.org/tunes/7/abc",
-        "https://thesession.org/tunes/9999999/abc" # Non-existent
-    ]
+    print("Running scraper.py for scaled data acquisition...")
+
+    # Define a range of tune IDs to scrape from thesession.org
+    START_ID = 1
+    END_ID = 500  # Let's aim for the first 500 tunes
+    
+    # Generate the list of target URLs
+    target_urls = [f"https://thesession.org/tunes/{i}/abc" for i in range(START_ID, END_ID + 1)]
+    
+    print(f"Will attempt to scrape {len(target_urls)} URLs from thesession.org...")
+
     all_scraped_abc = []
-    for url in target_urls:
-        time.sleep(1)
+    success_count = 0
+    fail_count = 0
+
+    for i, url in enumerate(target_urls):
+        # The print statement can be verbose, so we'll print progress every 25 tunes
+        if (i + 1) % 25 == 0:
+            print(f"Scraping progress: {i+1}/{len(target_urls)}")
+            
         abc_data_list = get_abc_from_url(url)
-        if abc_data_list: # Ensures abc_data_list is not None and not empty
+        if abc_data_list:
             all_scraped_abc.extend(abc_data_list)
+            success_count += 1
+        else:
+            fail_count += 1
+        
+        # Be polite to the server: a small delay between requests
+        time.sleep(0.2)
+
+    print(f"\nScraping complete. Successfully fetched from {success_count} URLs, failed for {fail_count} URLs.")
 
     if all_scraped_abc:
-        save_abc_data(all_scraped_abc, "initial_scraped_tunes_v1.txt")
+        save_abc_data(all_scraped_abc, "initial_scraped_tunes_large_v1.txt")
     else:
         print("No ABC data was scraped successfully in this test run.")


### PR DESCRIPTION
Hi team,

This PR contains the new scaled data pipeline.

Changes:

    scraper.py now iterates through a range of tune IDs on thesession.org.

    preprocess_data.py now correctly splits multi-setting tune blocks into individual training examples.

For the LLM Lead:
You can now use these scripts to generate the finetuning_dataset_large_v1.jsonl file needed for fine_tune.py.

This resolves the data blocker and should enable fine-tuning runs.